### PR TITLE
Enabled config flag for info logging

### DIFF
--- a/app/code/community/Adyen/Subscription/Helper/Data.php
+++ b/app/code/community/Adyen/Subscription/Helper/Data.php
@@ -25,17 +25,23 @@ class Adyen_Subscription_Helper_Data extends Mage_Core_Helper_Abstract
 {
     public function logSubscriptionCron($message)
     {
-        $this->log($message, "adyen_subscription_cron");
+        if ($this->_getInfoLoggingEnabled()) {
+            $this->log($message, "adyen_subscription_cron");
+        }
     }
 
     public function logQuoteCron($message)
     {
-        $this->log($message, "adyen_quote_cron");
+        if ($this->_getInfoLoggingEnabled()) {
+            $this->log($message, "adyen_quote_cron");
+        }
     }
 
     public function logOrderCron($message)
     {
-        $this->log($message, "adyen_order_cron");
+        if ($this->_getInfoLoggingEnabled()) {
+            $this->log($message, "adyen_order_cron");
+        }
     }
 
     public function log($message, $filename)
@@ -47,6 +53,14 @@ class Adyen_Subscription_Helper_Data extends Mage_Core_Helper_Abstract
         {
             Mage::log($message, Zend_Log::DEBUG, "$filename.log", true);
         }
+    }
+
+    protected function _getInfoLoggingEnabled()
+    {
+        return Mage::getStoreConfigFlag(
+            'adyen_subscription/advanced/enable_logging',
+            Mage::app()->getStore()
+        );
     }
 
     /**

--- a/app/code/community/Adyen/Subscription/etc/config.xml
+++ b/app/code/community/Adyen/Subscription/etc/config.xml
@@ -427,6 +427,7 @@
             </general>
             <advanced>
                 <schedule_quotes_term>P2W</schedule_quotes_term>
+                <enable_logging>0</enable_logging>
             </advanced>
         </adyen_subscription>
     </default>

--- a/app/code/community/Adyen/Subscription/etc/system.xml
+++ b/app/code/community/Adyen/Subscription/etc/system.xml
@@ -262,6 +262,16 @@
                             <comment><![CDATA[<b style="color:#eb5e00;">Important note: use the following notation:</b>
                             <a target="_blank" href="http://php.net/manual/en/dateinterval.createfromdatestring.php">http://php.net/manual/en/dateinterval.createfromdatestring.php</a>]]></comment>
                         </schedule_quotes_term>
+                        <enable_logging translate="label,comment">
+                            <label>Enable info logging</label>
+                            <tooltip><![CDATA[Info level messages from orders, quotes and subscriptions logged]]></tooltip>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <sort_order>20</sort_order>
+                        </enable_logging>
                     </fields>
                 </advanced>
             </groups>


### PR DESCRIPTION
Store Config optie voor het loggen van info messages. Debuggen aanhouden op productie is een handige feature maar zou nog wel onderscheid willen kunnen maken tussen puur info berichten als "ScheduleDate of subscription (#xxxxxxx) is 2016-01-07 12:00:00" en dingen als API feedback