### PR TITLE
[TASK] Added check to retry order creation on error state

### DIFF
--- a/app/code/community/Adyen/Subscription/Model/Cron.php
+++ b/app/code/community/Adyen/Subscription/Model/Cron.php
@@ -173,6 +173,16 @@ class Adyen_Subscription_Model_Cron
         foreach ($subscriptionCollection as $subscription) {
             /** @var Adyen_Subscription_Model_Subscription $subscription */
 
+            // If the subscription has an error status check in config if it should be retried
+            $retryOnError = Mage::getStoreConfigFlag('adyen_subscription/subscription/retry_on_error');
+            if(in_array($subscription->getStatus(), [
+                Adyen_Subscription_Model_Subscription::STATUS_QUOTE_ERROR,
+                Adyen_Subscription_Model_Subscription::STATUS_ORDER_ERROR,
+                Adyen_Subscription_Model_Subscription::STATUS_SUBSCRIPTION_ERROR
+            ]) && !$retryOnError) {
+                continue;
+            }
+
             if($subscription->getStatus() == Adyen_Subscription_Model_Subscription::STATUS_PAYMENT_ERROR) {
 
                 $retryFailedPayment = Mage::getStoreConfigFlag(

--- a/app/code/community/Adyen/Subscription/etc/config.xml
+++ b/app/code/community/Adyen/Subscription/etc/config.xml
@@ -428,6 +428,9 @@
             <advanced>
                 <schedule_quotes_term>P2W</schedule_quotes_term>
             </advanced>
+            <subscription>
+                <retry_on_error>0</retry_on_error>
+            </subscription>
         </adyen_subscription>
     </default>
 </config>

--- a/app/code/community/Adyen/Subscription/etc/system.xml
+++ b/app/code/community/Adyen/Subscription/etc/system.xml
@@ -138,6 +138,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </pause_hold_orders>
+                        <retry_on_error>
+                            <label>Retry creating order</label>
+                            <tooltip>If the subscription has an error status don't try to create an order</tooltip>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>47</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </retry_on_error>
                         <retry_failed_payment>
                             <label>Retry failed payment</label>
                             <tooltip>If the payment of the subscription is failed do you want to retry this later</tooltip>


### PR DESCRIPTION
When a subscription has an error state prevent quote to order conversion via cron.  Errors should first be resolved. 

Came accross this issue with a refused payment on a subscription, each half hour a (paid) call went out to Adyen that failed anyway