### PR TITLE
[BUGFIX] Using custom sorting method since aliases cant be referenced

### DIFF
--- a/app/code/community/Adyen/Subscription/Block/Adminhtml/Subscription/Grid.php
+++ b/app/code/community/Adyen/Subscription/Block/Adminhtml/Subscription/Grid.php
@@ -52,6 +52,17 @@ class Adyen_Subscription_Block_Adminhtml_Subscription_Grid extends Mage_Adminhtm
         return parent::_prepareCollection();
     }
 
+    protected function _customCustomerIncrementIdSort($collection, $column)
+    {
+        if (!$value = $column->getFilter()->getValue()) {
+            return $this;
+        }
+
+        $collection->getSelect()->where("ce.increment_id = " . $value);
+
+        return $this;
+    }
+
     protected function _prepareColumns()
     {
         $helper = Mage::helper('adyen_subscription');
@@ -86,6 +97,7 @@ class Adyen_Subscription_Block_Adminhtml_Subscription_Grid extends Mage_Adminhtm
             $this->addColumn('customer_increment_id', [
                 'header'    => $helper->__('Customer Inc.'),
                 'index'     => 'customer_increment_id',
+                'filter_condition_callback' => array($this, '_customCustomerIncrementIdSort')
             ]);
         }
 


### PR DESCRIPTION
Sorting on human friendly customer ID caused `Column not found: 1054 Unknown column 'customer_increment_id' in 'where clause'`