### PR TITLE
Update sql fixed

### DIFF
--- a/app/code/community/Adyen/Subscription/sql/adyen_subscription_setup/upgrade-0.13.0-0.14.0.php
+++ b/app/code/community/Adyen/Subscription/sql/adyen_subscription_setup/upgrade-0.13.0-0.14.0.php
@@ -44,7 +44,6 @@ $connection->addForeignKey(
     $subscriptionQuoteTable, 'order_id', $orderTable, 'entity_id'
 );
 
-$connection->dropIndex($subscriptionQuoteTable, 'quote_id');
 $quoteTable = $installer->getTable('sales/quote');
 $connection->addForeignKey(
     $installer->getFkName($subscriptionQuoteTable, 'quote_id', $quoteTable, 'entity_id'),

--- a/app/code/community/Adyen/Subscription/sql/adyen_subscription_setup/upgrade-0.19.0-0.20.0.php
+++ b/app/code/community/Adyen/Subscription/sql/adyen_subscription_setup/upgrade-0.19.0-0.20.0.php
@@ -33,8 +33,10 @@ $subscriptionAddressTable = $installer->getTable('adyen_subscription/subscriptio
 
 $connection->modifyColumn($subscriptionAddressTable, 'item_id', [
     'type'           => Varien_Db_Ddl_Table::TYPE_INTEGER,
-    'auto_increment' => true,
+	'auto_increment' => true,
     'unsigned'       => true,
+	'nullable'       => false,
+    'primary'        => true,
 ]);
 
 $installer->endSetup();


### PR DESCRIPTION
I have installed latest Magento CE 1.9.2.4 together with Adyen Payment 2.6.3. After that, I have copied Adyen Subscription 1.2.0 into the root folder. I got two exceptions. First during upgrade-0.13.0-0.14.0.php and second during upgrade-0.19.0-0.20.0.php 

I am using MySQL  5.7.13 on Ubuntu 16.04.2

Those two fixes helped me successfully install  Adyen Subscription into my Magento.