### PR TITLE
Update adyen/payment dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
         }
     ],
     "require": {
-        "adyen/payment": "2.5.*"
+        "adyen/payment": "2.8.*"
     }
 }


### PR DESCRIPTION
The dependency was still on adyen/payment 2.5.x while 2.8.x was already released and works with the subscription module