### PR TITLE
Feature option: create orders by date, disregarding time

### DIFF
--- a/app/code/community/Adyen/Subscription/Model/Cron.php
+++ b/app/code/community/Adyen/Subscription/Model/Cron.php
@@ -159,8 +159,11 @@ class Adyen_Subscription_Model_Cron
     public function createOrders()
     {
         Mage::helper('adyen_subscription')->logOrderCron("Start order cronjob");
+
+        $useTimeFetchingOrders = Mage::getStoreConfigFlag('adyen_subscription/subscription/create_order_regard_time');
+
         $subscriptionCollection = Mage::getResourceModel('adyen_subscription/subscription_collection');
-        $subscriptionCollection->addPlaceOrderFilter();
+        $subscriptionCollection->addPlaceOrderFilter($useTimeFetchingOrders);
 
         if ($subscriptionCollection->count() <= 0) {
             Mage::helper('adyen_subscription')->logOrderCron("There are no subscriptions that have quotes and a schedule date in the past");

--- a/app/code/community/Adyen/Subscription/Model/Resource/Subscription/Collection.php
+++ b/app/code/community/Adyen/Subscription/Model/Resource/Subscription/Collection.php
@@ -146,9 +146,10 @@ class Adyen_Subscription_Model_Resource_Subscription_Collection extends Mage_Cor
 
 
     /**
+     * @param boolean $useTime
      * @return $this
      */
-    public function addPlaceOrderFilter()
+    public function addPlaceOrderFilter($useTime = true)
     {
         $this->addFieldToFilter('status', array('in' => Adyen_Subscription_Model_Subscription::getPlaceOrderStatuses()));
         $this->getSelect()->joinLeft(
@@ -157,8 +158,11 @@ class Adyen_Subscription_Model_Resource_Subscription_Collection extends Mage_Cor
             ['quote_id', 'order_id']
         );
 
+        // if use time is false 'scheduled_at' should be cast to date, truncating time
+        $whereClauseForScheduled = $useTime ? "scheduled_at <= ?" : "DATE(scheduled_at) <= ?" ;
+
         $this->getSelect()
-            ->where("scheduled_at < ?", now())
+            ->where($whereClauseForScheduled, now())
             ->where('subscription_quote.order_id IS NULL')
             ->where('subscription_quote.quote_id IS NOT NULL');
 

--- a/app/code/community/Adyen/Subscription/etc/config.xml
+++ b/app/code/community/Adyen/Subscription/etc/config.xml
@@ -434,6 +434,7 @@
             </advanced>
             <subscription>
                 <retry_on_error>0</retry_on_error>
+                <create_order_regard_time>1</create_order_regard_time>
             </subscription>
         </adyen_subscription>
     </default>

--- a/app/code/community/Adyen/Subscription/etc/system.xml
+++ b/app/code/community/Adyen/Subscription/etc/system.xml
@@ -222,6 +222,16 @@
                             <sort_order>120</sort_order>
                             <show_in_default>1</show_in_default>
                         </cron_order_setting>
+                        <create_order_regard_time translate="label comment">
+                            <label>Use time for order creation</label>
+                            <tooltip><![CDATA[When set to no the order will be created as soon as the date is reached not waiting for the right time]]></tooltip>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <sort_order>130</sort_order>
+                        </create_order_regard_time>
                     </fields>
                 </subscription>
                 <order translate="label">


### PR DESCRIPTION
When a subscription contains physical products it's preferred to create the orders during the night to save system load and prepare orders for shipping on time, spreading the workload in the warehouse.

This feature which is backwards compatible to, by default, still use the time for retrieving subscriptions eligible for order creation gives the admin in the system > configuration the option to ignore time. Orders will be created just after midnight