### PR TITLE
Delay creating a subscription for order for 15 minutes

### DIFF
--- a/app/code/community/Adyen/Subscription/Model/Cron.php
+++ b/app/code/community/Adyen/Subscription/Model/Cron.php
@@ -56,6 +56,7 @@ class Adyen_Subscription_Model_Cron
         $collection->addFieldToFilter('product_options', array('nlike' => '%;s:18:"adyen_subscription";s:4:"none"%'));
         $collection->addFieldToFilter('created_adyen_subscription', array('null' => true));
         $collection->addFieldToFilter('bao.agreement_id', array('notnull' => true)); // must have a billing agreements
+        $collection->addFieldToFilter('main_table.created_at', array('lteq' => date('Y-m-d', now() - (15 * 60))));
         $collection->getSelect()->group('main_table.entity_id');
 
         $o = $p = $e = 0;


### PR DESCRIPTION
When users create orders in the backend it, quite frequently, happens they make a mistake and decide to either edit or cancel the order.
Because the create subscription cronjob runs every 5 minutes this means the order is still picked up to create a subscription before the admin decides to take above action.
A small delay in creating subscriptions of 15 minutes will eliminate this issue