### PR TITLE
Allow customer to cancel billing agreement, if no active subscriptions is present

### DIFF
--- a/app/code/community/Adyen/Subscription/Model/Observer.php
+++ b/app/code/community/Adyen/Subscription/Model/Observer.php
@@ -406,7 +406,8 @@ class Adyen_Subscription_Model_Observer extends Mage_Core_Model_Abstract
 
         $subscriptionCollection = Mage::getModel('adyen_subscription/subscription')
             ->getCollection()
-            ->addFieldToFilter('billing_agreement_id', $agreementId);
+            ->addFieldToFilter('billing_agreement_id', $agreementId)
+            ->addFieldToFilter('status', ['neq' => Adyen_Subscription_Model_Subscription::STATUS_CANCELED]);
 
         if ($subscriptionCollection->count() > 0) {
             Mage::throwException(Mage::helper('adyen_subscription')->__(


### PR DESCRIPTION
At the moment customers can't cancel billing agreement as long as there is subscriptions linked to it even though those subscriptions are canceled.

This change filters out canceled subscriptions from the check and allows customer to cancel billing agreement, if there is no longer active subscriptions.